### PR TITLE
chore: use new circleci docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
 
 docker: &DOCKER_NODE
   docker:
-    - image: circleci/node:10.22
+    - image: cimg/node:lts
 
 jobs:
   install:


### PR DESCRIPTION
potentially speeds up builds