### PR TITLE
chore: only notify slack on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,7 @@
 version: 2.1
 
-commands:
-  notify_slack_failure:
-    steps:
-      - run:
-          name: Notify Slack of failure if on master
-          command: |
-            if [ "$CIRCLE_BRANCH" = "master" ]; then
-              curl -X POST -H 'Content-type: application/json' --data "{\"text\":\":boom: ${CIRCLE_JOB} failed: ${CIRCLE_BUILD_URL}\"}" https://hooks.slack.com/services/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
-            fi
-          when: on_fail
+orbs:
+  slack: circleci/slack@3.4.2
 
 docker: &DOCKER_NODE
   docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ jobs:
           root: ~/
           paths:
             - project
-      - notify_slack_failure
+      - notify_slack_failure:
+          only_for_branches: master
 
   test:
     <<: *DOCKER_NODE
@@ -44,7 +45,8 @@ jobs:
       - run:
           command: npm run test -- --maxWorkers=4
           no_output_timeout: 3m
-      - notify_slack_failure
+      - notify_slack_failure:
+          only_for_branches: master
 
   lint:
     <<: *DOCKER_NODE
@@ -53,7 +55,8 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: npm run lint
-      - notify_slack_failure
+      - notify_slack_failure:
+          only_for_branches: master
 
   build:
     <<: *DOCKER_NODE
@@ -65,7 +68,8 @@ jobs:
             root: ~/
             paths:
               - project/pkg
-      - notify_slack_failure
+      - notify_slack_failure:
+          only_for_branches: master
 
   release:
     <<: *DOCKER_NODE
@@ -73,7 +77,8 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: npx semantic-release
-      - notify_slack_failure
+      - notify_slack_failure:
+          only_for_branches: master
 
   pre_release:
     <<: *DOCKER_NODE
@@ -82,7 +87,8 @@ jobs:
           at: ~/
       # manually set PR shell variables to empty to build pull request
       - run: CI_PULL_REQUEST= CIRCLE_PULL_REQUEST= npx semantic-release
-      - notify_slack_failure
+      - notify_slack_failure:
+          only_for_branches: master
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           root: ~/
           paths:
             - project
-      - notify_slack_failure:
+      - slack/notify-on-failure:
           only_for_branches: master
 
   test:
@@ -37,7 +37,7 @@ jobs:
       - run:
           command: npm run test -- --maxWorkers=4
           no_output_timeout: 3m
-      - notify_slack_failure:
+      - slack/notify-on-failure:
           only_for_branches: master
 
   lint:
@@ -47,7 +47,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: npm run lint
-      - notify_slack_failure:
+      - slack/notify-on-failure:
           only_for_branches: master
 
   build:
@@ -60,7 +60,7 @@ jobs:
             root: ~/
             paths:
               - project/pkg
-      - notify_slack_failure:
+      - slack/notify-on-failure:
           only_for_branches: master
 
   release:
@@ -69,7 +69,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - run: npx semantic-release
-      - notify_slack_failure:
+      - slack/notify-on-failure:
           only_for_branches: master
 
   pre_release:
@@ -79,7 +79,7 @@ jobs:
           at: ~/
       # manually set PR shell variables to empty to build pull request
       - run: CI_PULL_REQUEST= CIRCLE_PULL_REQUEST= npx semantic-release
-      - notify_slack_failure:
+      - slack/notify-on-failure:
           only_for_branches: master
 
 


### PR DESCRIPTION
we currently notify slack on every branch and that generates unnecessary noise from the branch deployments